### PR TITLE
fix: add missing closing anchor tag

### DIFF
--- a/501/vite-project/src/App.tsx
+++ b/501/vite-project/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
       <div>
         <a href="/src/class1/A01027983/">
           <button>A01027983</button>
+        </a>
         <a href='../src/class3/A01029143/pages/Menu.html'>
           Menu A01029143
         </a>


### PR DESCRIPTION
The only problem was both anchors where sharing the same closing tag,
and hence one was missing. This gets rid of that problem without
changing any further implementations.
